### PR TITLE
Update nbsp-french.php

### DIFF
--- a/nbsp-french.php
+++ b/nbsp-french.php
@@ -40,6 +40,7 @@ if ( ! class_exists( 'NbspFrench' ) ) {
 			'the_title'                     => 1000,
 			'the_content'                   => 1000,
 			'the_excerpt'                   => 1000,
+			'get_the_excerpt'               => 1000,
 			'comment_text'                  => 1000,
 			'widget_title'                  => 1000,
 			'widget_text'                   => 1000,


### PR DESCRIPTION
get_the_excerpt in default filters. Note that I didnt update the plugin version myself.

I had a WP Theme which needed to add this filter, it seems it is the function it used to display excerpt on its archive pages (BizBoost).

Also, was there anyway to add/remove filters to be processed by this plugin which didn't require to edit the plugin, or the text processing function of this plugin on arbitrary text? Would be more flexible than having to edit the plugin manually.

Thx!