### PR TITLE
add ability to get applied filter list from outside the class

### DIFF
--- a/nbsp-french.php
+++ b/nbsp-french.php
@@ -46,11 +46,15 @@ if ( ! class_exists( 'NbspFrench' ) ) {
 			'woocommerce_short_description' => 1000,
 		);
 
+		private $applied_filters;
+
 		public function __construct() {
 
 			add_action( 'plugins_loaded', array( $this, 'init_textdomain' ) );
 
-			foreach ( apply_filters( 'nbsp_french_add_filters', self::$filters ) as $filter_name => $filter_prio ) {
+			$this->applied_filters = apply_filters( 'nbsp_french_add_filters', self::$filters );
+
+			foreach ( $this->applied_filters as $filter_name => $filter_prio ) {
 
 				add_filter( $filter_name, array( __CLASS__, 'filter' ), $filter_prio );
 			}
@@ -64,6 +68,10 @@ if ( ! class_exists( 'NbspFrench' ) ) {
 			}
 
 			return self::$instance;
+		}
+
+		public function get_applied_filters() {
+			return $this->applied_filters;
 		}
 
 		public function init_textdomain() {


### PR DESCRIPTION
This would be useful to be able to remove the filters applied by nbsp-french from external functions. In my use-case, we have a multilingual editorial website using Polylang where we want the non-breaking spaces to be applied only on French content so we would remove the filters if the current language is not French.

Current code in use:
```PHP
if ( class_exists( 'NbspFrench' ) && 'fr' !== $lang ) {
	$filters = array(
		'the_title'                     => 1000,
		'the_content'                   => 1000,
		'the_excerpt'                   => 1000,
		'comment_text'                  => 1000,
		'widget_title'                  => 1000,
		'widget_text'                   => 1000,
		'woocommerce_short_description' => 1000,
	);
	foreach ( apply_filters( 'nbsp_french_add_filters', $filters ) as $filter_name => $filter_prio ) {
		remove_filter( $filter_name, array( 'NbspFrench', 'filter' ), $filter_prio );
	}
}
```

This static array should be replaced with `NbspFrench::get_instance()->get_applied_filters()` to be consistent upon updates.